### PR TITLE
increase timeout

### DIFF
--- a/jobs/build-and-verify/jenkins.groovy
+++ b/jobs/build-and-verify/jenkins.groovy
@@ -1,6 +1,6 @@
 node {
     try {
-        timeout(time: 10, unit: 'MINUTES') {
+        timeout(time: 30, unit: 'MINUTES') {
 
             // configure Tools and Environment.
             def buildNumber = "$env.BUILD_NUMBER"


### PR DESCRIPTION
Increase timeout to **30** min.

This because of the OpenShift task timeouts.

OpenShift Build timeout: **15** min.
Verify OpenShift Deployment timeout: **10** min.